### PR TITLE
#25 updatepost create command

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
   "name": "Finesse Frontend Node.js project",
   // Use 'postCreateCommand' to run commands after the container is created.
   "image": "mcr.microsoft.com/devcontainers/javascript-node:0-18",
-  "postCreateCommand": "npm install -g npm@9.8.1 --force",
+  "postCreateCommand": "npm install -g npm@9.8.1 --force && npm i @saithodev/ts-appversion",
 
   // Configure tool-specific properties.
   // "customizations": {},

--- a/package.json
+++ b/package.json
@@ -57,9 +57,5 @@
     "eslint-config-prettier": "^8.9.0",
     "eslint-config-standard-with-typescript": "^37.0.0",
     "eslint-plugin-prettier": "^5.0.0"
-  },
-  "engines" : { 
-    "npm" : "^9.8.1",
-    "node" : "^18.16.0"
   }
 }

--- a/src/_versions.ts
+++ b/src/_versions.ts
@@ -11,8 +11,8 @@ export interface TsAppVersion {
 export const versions: TsAppVersion = {
     version: '0.1.0',
     name: 'louis-finesse',
-    versionDate: '2023-07-27T19:01:19.184Z',
-    gitCommitHash: '4eed505',
-    versionLong: '0.1.0-4eed505',
+    versionDate: '2023-10-23T15:10:05.957Z',
+    gitCommitHash: '23ecae9',
+    versionLong: '0.1.0-23ecae9',
 };
 export default versions;


### PR DESCRIPTION
- Added @saithodev/ts-appversion to post-create installation.
- Removed 'engines' field from package.json to resolve postCreateCommand error failing issue
       - Resolved the npm version conflict that was preventing a succesful package installation in dev container.
       - 'saithodev/ts-appversion' can now be installed without issues.

#24 
#25 