### PR TITLE
Issue #268: adds docker-compose to enable local preview of Finesse

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -40,6 +40,19 @@ To get started with the project, follow the steps below:
    Use arg `-e PORT=<port> -p 5000:<port>` if you wish to control the internal
    port.
 
+### Docker-compose (optional)
+
+You can also use `docker-compose` to run the API with the client. The API is
+the backend that this client uses and is available at <https://github.com/ai-cfia/finesse-backend>.
+
+To run the API and the client together, you can use the following command:
+
+```bash
+docker-compose up --build
+```
+
+You can then access the client at <http://localhost>.
+
 ### Testing application
 
 `npm test`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,50 @@
+version: '3.8'
+
+services:
+  nginx:
+    image: ghcr.io/ai-cfia/nginx:latest
+    ports:
+      - "80:80"
+    environment:
+      - BACKEND_PORT=8080
+      - FRONTEND_PORT=3000
+    depends_on:
+      - backend
+      - frontend
+    networks:
+      - finesse-network
+
+  backend:
+    image: ghcr.io/ai-cfia/finesse-frontend:main
+    command: ["/bin/sh", "-c", "gunicorn --bind :8080 --workers 1 --threads 8 --timeout 0 --forwarded-allow-ips '*' app:app"]
+    ports:
+      - "8080:8080"
+    env_file:
+      - .env
+    environment:
+      - PORT=8080
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+    networks:
+      - finesse-network
+
+  frontend:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "3000:3000"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3000/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+    networks:
+      - finesse-network
+
+networks:
+  finesse-network:
+    driver: bridge


### PR DESCRIPTION
This adds a docker-compose to enable local preview of the frontend and  backend working together. It pulls the image of the backend from the registry and it uses the local dockerfile of the frontend to enable preview of current changes.